### PR TITLE
Make header underline bar full tab width by default.

### DIFF
--- a/TabViewSample/TabViewSample.Android/TabViewSample.Android.csproj
+++ b/TabViewSample/TabViewSample.Android/TabViewSample.Android.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TabViewSample.Droid</RootNamespace>
     <AssemblyName>TabViewSample.Android</AssemblyName>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -84,7 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TabViewSample\TabViewSample.csproj">
-      <Project>{99F5DCC3-FBCB-42C1-B608-919132027C6D}</Project>
+      <Project>{A1BE3D09-4218-4BA3-BB05-960D3C6A6FC7}</Project>
       <Name>TabViewSample</Name>
     </ProjectReference>
   </ItemGroup>

--- a/TabViewSample/TabViewSample.iOS/TabViewSample.iOS.csproj
+++ b/TabViewSample/TabViewSample.iOS/TabViewSample.iOS.csproj
@@ -127,7 +127,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\TabViewSample\TabViewSample.csproj">
-      <Project>{99F5DCC3-FBCB-42C1-B608-919132027C6D}</Project>
+      <Project>{A1BE3D09-4218-4BA3-BB05-960D3C6A6FC7}</Project>
       <Name>TabViewSample</Name>
     </ProjectReference>
   </ItemGroup>

--- a/TabViewSample/TabViewSample/App.xaml.cs
+++ b/TabViewSample/TabViewSample/App.xaml.cs
@@ -13,7 +13,7 @@ namespace TabViewSample
 		{
 			InitializeComponent();
 
-            MainPage = new NavigationPage(new MainPage());
+                        MainPage = new NavigationPage(new MainPage());
 		}
 
 		protected override void OnStart ()

--- a/TabViewSample/TabViewSample/App.xaml.cs
+++ b/TabViewSample/TabViewSample/App.xaml.cs
@@ -13,7 +13,7 @@ namespace TabViewSample
 		{
 			InitializeComponent();
 
-			MainPage = new TabViewSample.MainPage();
+            MainPage = new NavigationPage(new MainPage());
 		}
 
 		protected override void OnStart ()

--- a/TabViewSample/TabViewSample/MainPage.xaml
+++ b/TabViewSample/TabViewSample/MainPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:TabViewSample"
@@ -21,6 +21,7 @@
                     <Button Text="Change tab header text font size" Clicked="Button_ChangeTabTextFontSize" HorizontalOptions="Start"/>
                     <Button Text="Change tab header text font family" Clicked="Button_ChangeTabTextFontFamily" HorizontalOptions="Start"/>
                     <Button Text="Change tab header text font attributes" Clicked="Button_ChangeTabTextFontAttributes" HorizontalOptions="Start"/>
+                    <Button Text="Go to Xaml sample page" Clicked="GoToXamlSample" HorizontalOptions="Start" />
                 </StackLayout>
             </ScrollView>
         </StackLayout>

--- a/TabViewSample/TabViewSample/MainPage.xaml.cs
+++ b/TabViewSample/TabViewSample/MainPage.xaml.cs
@@ -66,7 +66,7 @@ namespace TabViewSample
 
         private void Button_RemoveLastTab(object sender, EventArgs e)
         {
-            tabView.ItemSource.Remove(tabView.ItemSource.LastOrDefault());
+            tabView.RemoveTab(tabView.ItemSource.Count - 1);
         }
 
         private void Button_ChangeTextColor(object sender, EventArgs e)
@@ -102,6 +102,11 @@ namespace TabViewSample
         private void Button_ChangeTabTextFontFamily(object sender, EventArgs e)
         {
             tabView.HeaderTabTextFontFamily = tabView.HeaderTabTextFontFamily == "Droid Sans Mono" ? "Comic Sans MS" : "Droid Sans Mono";
+        }
+
+        private async void GoToXamlSample(object sender, EventArgs e)
+        {
+            await Navigation.PushAsync(new XamlSamplePage());
         }
     }
 }

--- a/TabViewSample/TabViewSample/TabViewSample.csproj
+++ b/TabViewSample/TabViewSample/TabViewSample.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xam.Plugin.TabView" Version="1.0.3" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
   </ItemGroup>
 
@@ -16,5 +15,8 @@
     <Compile Condition=" '$(EnableDefaultCompileItems)' == 'true' " Update="MainPage.xaml.cs">
       <DependentUpon>*.xaml</DependentUpon>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Xam.Plugin.TabView\Xam.Plugin.TabView.csproj" />
   </ItemGroup>
 </Project>

--- a/TabViewSample/TabViewSample/XamlSamplePage.xaml
+++ b/TabViewSample/TabViewSample/XamlSamplePage.xaml
@@ -4,7 +4,7 @@
              x:Class="TabViewSample.XamlSamplePage"
              xmlns:tvs="clr-namespace:Xam.Plugin.TabView;assembly=Xam.Plugin.TabView">
     <ContentPage.Content>
-        <tvs:TabViewControl>
+        <tvs:TabViewControl HeaderTabTextFontSize="Default">
             <tvs:TabViewControl.ItemSource>
                 <tvs:TabItem HeaderText="First Tab">
                     <Button Text="Go back to main page from first page" Clicked="GoBackClicked"/>

--- a/TabViewSample/TabViewSample/XamlSamplePage.xaml
+++ b/TabViewSample/TabViewSample/XamlSamplePage.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             x:Class="TabViewSample.XamlSamplePage"
+             xmlns:tvs="clr-namespace:Xam.Plugin.TabView;assembly=Xam.Plugin.TabView">
+    <ContentPage.Content>
+        <tvs:TabViewControl>
+            <tvs:TabViewControl.ItemSource>
+                <tvs:TabItem HeaderText="First Tab">
+                    <Button Text="Go back to main page from first page" Clicked="GoBackClicked"/>
+                </tvs:TabItem>
+                <tvs:TabItem HeaderText="Second Tab">
+                    <Button Text="Go back to main page from second page" Clicked="GoBackClicked"/>
+                </tvs:TabItem>
+                <tvs:TabItem HeaderText="Third Tab">
+                    <Button Text="Go back to main page from third page" Clicked="GoBackClicked"/>
+                </tvs:TabItem>
+            </tvs:TabViewControl.ItemSource>
+        </tvs:TabViewControl>
+    </ContentPage.Content>
+</ContentPage>

--- a/TabViewSample/TabViewSample/XamlSamplePage.xaml.cs
+++ b/TabViewSample/TabViewSample/XamlSamplePage.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace TabViewSample
+{
+    public partial class XamlSamplePage : ContentPage
+    {
+        public XamlSamplePage()
+        {
+            InitializeComponent();
+        }
+
+        async void GoBackClicked(object sender, System.EventArgs e)
+        {
+            await Navigation.PopAsync();
+        }
+    }
+}

--- a/Xam.Plugin.TabView.sln
+++ b/Xam.Plugin.TabView.sln
@@ -195,6 +195,7 @@ Global
 		{B4235E46-CD20-4B22-8E94-749E3B7B456F}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{B4235E46-CD20-4B22-8E94-749E3B7B456F}.Release|x64.ActiveCfg = Release|iPhone
 		{B4235E46-CD20-4B22-8E94-749E3B7B456F}.Release|x86.ActiveCfg = Release|iPhone
+		{B4235E46-CD20-4B22-8E94-749E3B7B456F}.Debug|Any CPU.Build.0 = Debug|iPhone
 		{909B2717-A345-4085-BDE7-9D06500321BF}.Ad-Hoc|Any CPU.ActiveCfg = Release|x86
 		{909B2717-A345-4085-BDE7-9D06500321BF}.Ad-Hoc|Any CPU.Build.0 = Release|x86
 		{909B2717-A345-4085-BDE7-9D06500321BF}.Ad-Hoc|Any CPU.Deploy.0 = Release|x86

--- a/Xam.Plugin.TabView/Xam.Plugin.TabView.cs
+++ b/Xam.Plugin.TabView/Xam.Plugin.TabView.cs
@@ -310,7 +310,7 @@ namespace Xam.Plugin.TabView
             get { return (Color)GetValue(HeaderSelectionUnderlineColorProperty); }
             set { SetValue(HeaderSelectionUnderlineColorProperty, value); }
         }
-        public static void HeaderSelectionUnderlineColorChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderSelectionUnderlineColorChanged(BindableObject bindable, object oldValue, object newValue)
         {
             if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {

--- a/Xam.Plugin.TabView/Xam.Plugin.TabView.cs
+++ b/Xam.Plugin.TabView/Xam.Plugin.TabView.cs
@@ -33,7 +33,6 @@ namespace Xam.Plugin.TabView
         private Grid _headerContainerGrid;
         private CarouselViewControl _carouselView;
         private int _position = 0;
-        public static TabViewControl Context;
 
         public ObservableCollection<TabItem> ItemSource { get; set; }
 
@@ -56,7 +55,7 @@ namespace Xam.Plugin.TabView
         {
             //Parameterless constructor required for xaml instantiation.
         }
-        
+
         public TabViewControl(IList<TabItem> tabItems, int selectedTabIndex = 0)
         {
             Initialize(tabItems, selectedTabIndex);
@@ -65,43 +64,37 @@ namespace Xam.Plugin.TabView
         private void Initialize(IList<TabItem> tabItems, int selectedTabIndex = 0)
         {
             ItemSource = new ObservableCollection<TabItem>();
-
-            foreach (var tab in tabItems)
+            void setTabProperties()
             {
-                tab.HeaderTextColor = HeaderTabTextColor;
-                tab.HeaderSelectionUnderlineColor = HeaderSelectionUnderlineColor;
-                tab.HeaderSelectionUnderlineThickness = HeaderSelectionUnderlineThickness;
-                tab.HeaderSelectionUnderlineWidth = HeaderSelectionUnderlineWidth;
-                tab.HeaderTabTextFontSize = HeaderTabTextFontSize;
-                tab.HeaderTabTextFontFamily = HeaderTabTextFontFamily;
-                tab.HeaderTabTextFontAttributes = HeaderTabTextFontAttributes;
+                foreach (var tab in tabItems)
+                {
+                    tab.HeaderTextColor = HeaderTabTextColor;
+                    tab.HeaderSelectionUnderlineColor = HeaderSelectionUnderlineColor;
+                    tab.HeaderSelectionUnderlineThickness = HeaderSelectionUnderlineThickness;
+                    if (tab.HeaderSelectionUnderlineWidth > 0)
+                    {
+                        tab.HeaderSelectionUnderlineWidth = HeaderSelectionUnderlineWidth;
+                    }
+                    tab.HeaderTabTextFontSize = HeaderTabTextFontSize;
+                    tab.HeaderTabTextFontFamily = HeaderTabTextFontFamily;
+                    tab.HeaderTabTextFontAttributes = HeaderTabTextFontAttributes;
 
-                ItemSource.Add(tab);
+                    ItemSource.Add(tab);
+                }
             }
+            setTabProperties();
 
             Init();
 
             ItemSource.CollectionChanged += (object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) =>
             {
-                foreach (var tab in ItemSource)
-                {
-                    tab.HeaderTextColor = HeaderTabTextColor;
-                    tab.HeaderSelectionUnderlineColor = HeaderSelectionUnderlineColor;
-                    tab.HeaderSelectionUnderlineThickness = HeaderSelectionUnderlineThickness;
-                    tab.HeaderSelectionUnderlineWidth = HeaderSelectionUnderlineWidth;
-                    tab.HeaderTabTextFontSize = HeaderTabTextFontSize;
-                    tab.HeaderTabTextFontFamily = HeaderTabTextFontFamily;
-                    tab.HeaderTabTextFontAttributes = HeaderTabTextFontAttributes;
-                }
+                setTabProperties();
                 InitTabs();
             };
 
             _position = selectedTabIndex;
             InitTabs();
 
-            Context = this;
-
-            _carouselView.PropertyChanged += _carouselView_PropertyChanged;
             _carouselView.PropertyChanged += _carouselView_PropertyChanged;
         }
 
@@ -165,20 +158,20 @@ namespace Xam.Plugin.TabView
             Content = _mainContainerSL;
         }
 
-		protected override void OnBindingContextChanged()
-		{
-			base.OnBindingContextChanged();
-			if (BindingContext != null)
-			{
-				foreach (var tab in ItemSource)
-				{
-					if (tab is TabItem view)
-					{
-						view.Content.BindingContext = BindingContext;
-					}
-				}
-			}
-		}
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+            if (BindingContext != null)
+            {
+                foreach (var tab in ItemSource)
+                {
+                    if (tab is TabItem view)
+                    {
+                        view.Content.BindingContext = BindingContext;
+                    }
+                }
+            }
+        }
 
         private void _carouselView_PositionSelected(object sender, PositionSelectedEventArgs e)
         {
@@ -195,7 +188,7 @@ namespace Xam.Plugin.TabView
 
             for (int i = 0; i < ItemSource.Count; i++)
             {
-                _headerContainerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
+                _headerContainerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = tabSize });
 
                 var tab = ItemSource[i];
                 tab.IsCurrent = i == _position;
@@ -209,28 +202,28 @@ namespace Xam.Plugin.TabView
                     HorizontalOptions = LayoutOptions.CenterAndExpand,
                     VerticalOptions = LayoutOptions.Center
                 };
-                headerLabel.SetBinding(Label.TextProperty, "HeaderText");
-                headerLabel.SetBinding(Label.TextColorProperty, "HeaderTextColor");
-                headerLabel.SetBinding(Label.FontSizeProperty, "HeaderTabTextFontSize");
-                headerLabel.SetBinding(Label.FontFamilyProperty, "HeaderTabTextFontFamily");
-                headerLabel.SetBinding(Label.FontAttributesProperty, "HeaderTabTextFontAttributes");
+                headerLabel.SetBinding(Label.TextProperty, nameof(TabItem.HeaderText));
+                headerLabel.SetBinding(Label.TextColorProperty, nameof(TabItem.HeaderTextColor));
+                headerLabel.SetBinding(Label.FontSizeProperty, nameof(TabItem.HeaderTabTextFontSize));
+                headerLabel.SetBinding(Label.FontFamilyProperty, nameof(TabItem.HeaderTabTextFontFamily));
+                headerLabel.SetBinding(Label.FontAttributesProperty, nameof(TabItem.HeaderTabTextFontAttributes));
 
                 var selectionBarBoxView = new BoxView
                 {
-                    HorizontalOptions = LayoutOptions.CenterAndExpand,
                     VerticalOptions = LayoutOptions.EndAndExpand,
                     BindingContext = tab,
                     HeightRequest = HeaderSelectionUnderlineThickness,
                     WidthRequest = HeaderSelectionUnderlineWidth
                 };
-                selectionBarBoxView.SetBinding(BoxView.IsVisibleProperty, "IsCurrent");
-                selectionBarBoxView.SetBinding(BoxView.ColorProperty, "HeaderSelectionUnderlineColor");
-                selectionBarBoxView.SetBinding(BoxView.WidthProperty, "HeaderSelectionUnderlineWidth");
-                selectionBarBoxView.SetBinding(BoxView.HeightProperty, "HeaderSelectionUnderlineThickness");
+                selectionBarBoxView.HorizontalOptions = tab.HeaderSelectionUnderlineWidth > 0 ? LayoutOptions.CenterAndExpand : LayoutOptions.FillAndExpand;
+                selectionBarBoxView.SetBinding(BoxView.IsVisibleProperty, nameof(TabItem.IsCurrent));
+                selectionBarBoxView.SetBinding(BoxView.ColorProperty, nameof(TabItem.HeaderSelectionUnderlineColor));
+                selectionBarBoxView.SetBinding(BoxView.WidthProperty, nameof(TabItem.HeaderSelectionUnderlineWidth));
+                selectionBarBoxView.SetBinding(BoxView.HeightProperty, nameof(TabItem.HeaderSelectionUnderlineThickness));
 
                 selectionBarBoxView.PropertyChanged += (object sender, PropertyChangedEventArgs e) =>
                 {
-                    if (e.PropertyName == "IsCurrent")
+                    if (e.PropertyName == nameof(TabItem.IsCurrent))
                     {
                         SetPosition(ItemSource.IndexOf((TabItem)((BoxView)sender).BindingContext));
                     }
@@ -265,9 +258,12 @@ namespace Xam.Plugin.TabView
             get { return (Color)GetValue(HeaderBackgroundColorProperty); }
             set { SetValue(HeaderBackgroundColorProperty, value); }
         }
-        public static void HeaderBackgroundColorChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderBackgroundColorChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            Context._headerContainerGrid.BackgroundColor = (Color)newValue;
+            if (bindable is TabViewControl tabViewControl)
+            {
+                tabViewControl._headerContainerGrid.BackgroundColor = (Color)newValue;
+            }
         }
         public readonly BindableProperty HeaderBackgroundColorProperty = BindableProperty.Create(nameof(HeaderBackgroundColor), typeof(Color), typeof(TabViewControl), Color.Black, BindingMode.Default, null, HeaderBackgroundColorChanged);
         #endregion
@@ -278,11 +274,14 @@ namespace Xam.Plugin.TabView
             get { return (Color)GetValue(HeaderTabTextColorProperty); }
             set { SetValue(HeaderTabTextColorProperty, value); }
         }
-        public static void HeaderTabTextColorChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderTabTextColorChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderTextColor = (Color)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderTextColor = (Color)newValue;
+                }
             }
         }
         public readonly BindableProperty HeaderTabTextColorProperty =
@@ -295,9 +294,12 @@ namespace Xam.Plugin.TabView
             get { return (double)GetValue(ContentHeightProperty); }
             set { SetValue(ContentHeightProperty, value); }
         }
-        public static void ContentHeightChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void ContentHeightChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            Context._carouselView.HeightRequest = (double)newValue;
+            if (bindable is TabViewControl tabViewControl && tabViewControl._carouselView != null)
+            {
+                tabViewControl._carouselView.HeightRequest = (double)newValue;
+            }
         }
         public readonly BindableProperty ContentHeightProperty = BindableProperty.Create(nameof(ContentHeight), typeof(double), typeof(TabViewControl), (double)200, BindingMode.Default, null, ContentHeightChanged);
         #endregion
@@ -310,9 +312,12 @@ namespace Xam.Plugin.TabView
         }
         public static void HeaderSelectionUnderlineColorChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderSelectionUnderlineColor = (Color)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderSelectionUnderlineColor = (Color)newValue;
+                }
             }
         }
         public readonly BindableProperty HeaderSelectionUnderlineColorProperty = BindableProperty.Create(nameof(HeaderSelectionUnderlineColor), typeof(Color), typeof(TabViewControl), Color.White, BindingMode.Default, null, HeaderSelectionUnderlineColorChanged);
@@ -324,11 +329,14 @@ namespace Xam.Plugin.TabView
             get { return (double)GetValue(HeaderSelectionUnderlineThicknessProperty); }
             set { SetValue(HeaderSelectionUnderlineThicknessProperty, value); }
         }
-        public static void HeaderSelectionUnderlineThicknessChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderSelectionUnderlineThicknessChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderSelectionUnderlineThickness = (double)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderSelectionUnderlineThickness = (double)newValue;
+                }
             }
         }
         public readonly BindableProperty HeaderSelectionUnderlineThicknessProperty = BindableProperty.Create(nameof(HeaderSelectionUnderlineThickness), typeof(double), typeof(TabViewControl), (double)5, BindingMode.Default, null, HeaderSelectionUnderlineThicknessChanged);
@@ -340,14 +348,17 @@ namespace Xam.Plugin.TabView
             get { return (double)GetValue(HeaderSelectionUnderlineWidthProperty); }
             set { SetValue(HeaderSelectionUnderlineWidthProperty, value); }
         }
-        public static void HeaderSelectionUnderlineWidthChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderSelectionUnderlineWidthChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderSelectionUnderlineWidth = (double)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderSelectionUnderlineWidth = (double)newValue;
+                }
             }
         }
-        public readonly BindableProperty HeaderSelectionUnderlineWidthProperty = BindableProperty.Create(nameof(HeaderSelectionUnderlineWidth), typeof(double), typeof(TabViewControl), (double)40, BindingMode.Default, null, HeaderSelectionUnderlineWidthChanged);
+        public readonly BindableProperty HeaderSelectionUnderlineWidthProperty = BindableProperty.Create(nameof(HeaderSelectionUnderlineWidth), typeof(double), typeof(TabViewControl), (double)0, BindingMode.Default, null, HeaderSelectionUnderlineWidthChanged);
         #endregion
 
         #region HeaderTabTextFontSize
@@ -356,11 +367,14 @@ namespace Xam.Plugin.TabView
             get { return (double)GetValue(HeaderTabTextFontSizeProperty); }
             set { SetValue(HeaderTabTextFontSizeProperty, value); }
         }
-        public static void HeaderTabTextFontSizeChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderTabTextFontSizeChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderTabTextFontSize = (double)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderTabTextFontSize = (double)newValue;
+                }
             }
         }
         public readonly BindableProperty HeaderTabTextFontSizeProperty = BindableProperty.Create(nameof(HeaderTabTextFontSize), typeof(double), typeof(TabViewControl), (double)14, BindingMode.Default, null, HeaderTabTextFontSizeChanged);
@@ -372,11 +386,14 @@ namespace Xam.Plugin.TabView
             get { return (string)GetValue(HeaderTabTextFontFamilyProperty); }
             set { SetValue(HeaderTabTextFontFamilyProperty, value); }
         }
-        public static void HeaderTabTextFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderTabTextFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderTabTextFontFamily = (string)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderTabTextFontFamily = (string)newValue;
+                }
             }
         }
         public readonly BindableProperty HeaderTabTextFontFamilyProperty = BindableProperty.Create(nameof(HeaderTabTextFontFamily), typeof(string), typeof(TabViewControl), null, BindingMode.Default, null, HeaderTabTextFontFamilyChanged);
@@ -388,23 +405,26 @@ namespace Xam.Plugin.TabView
             get { return (FontAttributes)GetValue(HeaderTabTextFontAttributesProperty); }
             set { SetValue(HeaderTabTextFontAttributesProperty, value); }
         }
-        public static void HeaderTabTextFontAttributesChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void HeaderTabTextFontAttributesChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            foreach (var tab in Context.ItemSource)
+            if (bindable is TabViewControl tabViewControl && tabViewControl.ItemSource != null)
             {
-                tab.HeaderTabTextFontAttributes = (FontAttributes)newValue;
+                foreach (var tab in tabViewControl.ItemSource)
+                {
+                    tab.HeaderTabTextFontAttributes = (FontAttributes)newValue;
+                }
             }
         }
         public readonly BindableProperty HeaderTabTextFontAttributesProperty = BindableProperty.Create(nameof(HeaderTabTextFontAttributes), typeof(FontAttributes), typeof(TabViewControl), FontAttributes.None, BindingMode.Default, null, HeaderTabTextFontAttributesChanged);
         #endregion
 
-		#region TabItems
-        public static BindableProperty TabItemsProperty = BindableProperty.Create(nameof(TabItems), typeof(IList<TabItem>), typeof(TabViewControl), null, propertyChanged:OnTabItemsChanged);
+        #region TabItems
+        public static BindableProperty TabItemsProperty = BindableProperty.Create(nameof(TabItems), typeof(IList<TabItem>), typeof(TabViewControl), null, propertyChanged: OnTabItemsChanged);
         private static void OnTabItemsChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            if (bindable is TabViewControl tabControl)
+            if (bindable is TabViewControl tabViewControl)
             {
-                tabControl.Initialize(tabControl.TabItems);
+                tabViewControl.Initialize(tabViewControl.TabItems);
             }
         }
         public IList<TabItem> TabItems
@@ -415,29 +435,30 @@ namespace Xam.Plugin.TabView
         #endregion
 
         #region TabSizeOption
-		public static BindableProperty TabSizeOptionProperty = BindableProperty.Create(nameof(TabSizeOption), typeof(GridLength), typeof(TabViewControl), default(GridLength), propertyChanged: OnTabSizeOptionChanged);
-		private static void OnTabSizeOptionChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			if (bindable is TabViewControl tabViewControl)
-			{
-				if (tabViewControl._headerContainerGrid != null && tabViewControl.ItemSource != null)
-				{
-					foreach (var tabContainer in tabViewControl._headerContainerGrid.ColumnDefinitions)
-					{
-						tabContainer.Width = (GridLength)newValue;
-					}
-				}
-			}
-		}
-		public GridLength TabSizeOption
-		{
-			get => (GridLength)GetValue(TabSizeOptionProperty);
-			set { SetValue(TabSizeOptionProperty, value); }
-		}
-		#endregion
+        public static BindableProperty TabSizeOptionProperty = BindableProperty.Create(nameof(TabSizeOption), typeof(GridLength), typeof(TabViewControl), default(GridLength), propertyChanged: OnTabSizeOptionChanged);
+        private static void OnTabSizeOptionChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (bindable is TabViewControl tabViewControl && tabViewControl._headerContainerGrid != null && tabViewControl.ItemSource != null)
+            {
+                foreach (var tabContainer in tabViewControl._headerContainerGrid.ColumnDefinitions)
+                {
+                    tabContainer.Width = (GridLength)newValue;
+                }
+            }
+        }
+        public GridLength TabSizeOption
+        {
+            get => (GridLength)GetValue(TabSizeOptionProperty);
+            set { SetValue(TabSizeOptionProperty, value); }
+        }
+        #endregion
 
         public void SetPosition(int position)
         {
+            if (_position == position)
+            {
+                return;
+            }
             int oldPosition = _position;
 
             var positionChangingArgs = new PositionChangingEventArgs()

--- a/Xam.Plugin.TabView/Xam.Plugin.TabView.cs
+++ b/Xam.Plugin.TabView/Xam.Plugin.TabView.cs
@@ -417,6 +417,7 @@ namespace Xam.Plugin.TabView
         #endregion
 
         #region HeaderTabTextFontSize
+        [TypeConverter(typeof(FontSizeConverter))]
         public double HeaderTabTextFontSize
         {
             get { return (double)GetValue(HeaderTabTextFontSizeProperty); }
@@ -702,6 +703,7 @@ namespace Xam.Plugin.TabView
         }
 
         public static readonly BindableProperty HeaderTabTextFontSizeProperty = BindableProperty.Create(nameof(HeaderTabTextFontSize), typeof(double), typeof(TabItem), TabDefaults.DefaultTextSize);
+        [TypeConverter(typeof(FontSizeConverter))]
         public double HeaderTabTextFontSize
         {
             get => (double)GetValue(HeaderTabTextFontSizeProperty);

--- a/Xam.Plugin.TabView/Xam.Plugin.TabView.csproj
+++ b/Xam.Plugin.TabView/Xam.Plugin.TabView.csproj
@@ -42,32 +42,19 @@
     <Reference Include="CarouselView.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CarouselView.FormsPlugin.5.0.0\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+Xamarin.iOS10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Core.dll</HintPath>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.122203\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Platform.dll</HintPath>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.122203\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Xamarin.Forms.2.3.4.247\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.Xaml.dll</HintPath>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.122203\lib\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="..\packages\Xamarin.Forms.2.5.0.122203\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.122203\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />
 </Project>

--- a/Xam.Plugin.TabView/packages.config
+++ b/Xam.Plugin.TabView/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CarouselView.FormsPlugin" version="5.0.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="Xamarin.Forms" version="2.3.4.247" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Xamarin.Forms" version="2.5.0.122203" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
Replace magic strings with nameof(propertyName).
Replace Context property with bindable instances.